### PR TITLE
accept opts for css-parse, default filename to 'source.css'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ var fs = require('fs');
 var assert = require('assert');
 var cssdeps = require('cssdeps');
 
-var fixture = fs.readFileSync(__dirname + '/fixture.css', 'utf8');
+var file = __dirname + '/fixture.css';
+var fixture = fs.readFileSync(file, 'utf8');
+var options = { source: file };
 
-assert.deepEqual(cssdeps(fixture), [
+assert.deepEqual(cssdeps(fixture, options), [
   '/foo.css',
   '../bar.css',
   '../baz.css',

--- a/index.js
+++ b/index.js
@@ -3,9 +3,10 @@
 var parse = require('css-parse');
 
 module.exports = detect;
-function detect(src) {
+function detect(src, opts) {
   var res = [];
-  parseDeps(parse(src), res);
+  var options = Object.assign({ source: 'source.css' }, opts);
+  parseDeps(parse(src, options), res);
   return dedupe(res);
 }
 

--- a/index.js
+++ b/index.js
@@ -5,8 +5,9 @@ var parse = require('css-parse');
 module.exports = detect;
 function detect(src, opts) {
   var res = [];
-  var options = Object.assign({ source: 'source.css' }, opts);
-  parseDeps(parse(src, options), res);
+  if (!opts) opts = {};
+  if (!opts.source) opts.source = 'source.css';
+  parseDeps(parse(src, opts), res);
   return dedupe(res);
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -18,3 +18,15 @@ test('gets deps', function () {
     '../photoB.png'
   ]);
 });
+
+test('syntax error message', function () {
+  assert.throws(function () {
+    cssdeps('body {');   // syntax error
+  }, /source\.css:1:7/); // expect error message to include file name (default: source.css)
+})
+
+test('pass opts to css-parse', function () {
+  assert.throws(function () {
+    cssdeps('body {', { source: 'index.css' });   // syntax error
+  }, /index\.css:1:7/); // expect error message to include file name (default: source.css)
+});


### PR DESCRIPTION
For the `css-parse` dependency in `master`, if a syntax error is detected, it outputs something like:

```
Error: undefined:1:7: missing '}'
```

This is because no options are being passed to css-parse (namely to define `source: 'filename.css'`) This doesn't affect 1.0.0 of cssdeps, since this is new in 2.x of css-parse. (but that bump hasn't been published to npm yet, see #1)

This PR adds an `opts` parameter to cssdeps, which is passed along to `css-parse` (after defaulting `source: 'source.css'` for the sake of printing something other than `undefined`)
