### PR TITLE
Allow for custom syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,9 +53,6 @@ function parseDeps(ast, res) {
     case 'keyframes':
     case 'comment':
       break;
-    default:
-      /* istanbul ignore next */
-      throw new Error('Unexpected AST type ' + ast.type);
   }
 }
 function findUrls(str) {


### PR DESCRIPTION
Currently, hitting some token it does not recognize in the syntax tree causes an exception to be thrown. This is problematic if you're using a CSS-like syntax (via cssnext, myth, etc) despite that it is still parseable as CSS, but introduces extra features/syntax.
